### PR TITLE
Humble Sync #2: Bump to version 1.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,9 @@ ros2 launch roverrobotics_gazebo <robot>_gazebo.launch.py
 
 The 2wd_rover and 4wd_rover replace the Rover Zero and Rover Pro since they have the same footprint. The 2wd_rover implements our chassis with two driven front wheels and two rear casters and the 4wd_rover implements our chassis with 4 driven wheels in a skid steer configuration.
 
+Note: You have to install gazebo specifically for ROS. Our install script does not install gazebo. To install gazebo:
+```sudo apt install ros-{DISTRO}-ros-gz```
+
 ## Robot Description Setup
 Our ROS2 packages now implement URDF setups for all Rover Robots! The ``roverrobotics_description`` package implements all of the URDF configs and launches. You can view a URDF using the following:
 ```bash

--- a/README.md
+++ b/README.md
@@ -97,6 +97,14 @@ You may launch with a teleop node which will try to connect to a joystick:
 ros2 launch roverrobotics_driver <robot>_teleop.launch.py
 ```
 
+### What is launched with this?
+Our launch files launch (1) The Robot Driver, (2) The robot description, (3) an accessories launch, and (4) A PS4 Controller Driver.
+(1) The Robot Driver: responsible for interfacing with our robot and handling velocity commands as well as publishing wheel odometry
+(2) The Robot Description: responsible for publishing to the /robot_description topic and providing transforms between the base_link, chassis_link, and payload_link. Edit the URDF for your robot to define new frames or remove links
+(3) Accessories Launch: a convenience launch for sensor packages to run when the robot is launched. 
+(4) PS4 Controller Driver: handles input from the PS4 Controller
+
+
 ## Simulation with Gazebo
 Our ROS2 packages now support simulations for all robots! The ``roverrobotics_gazebo`` package implements all of the simulation launches. You can launch your simulation using the following:
 ```bash

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Installation is made simple through two options:
 
   
 
-#### ``(Recommended)``Option 1: Using the provided install script in the ``install_scripts`` folder
+#### ``(Recommended)``Option 1: Using the provided install script in the ``rover_install_scripts_ros2`` repo
 
   
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,53 @@ The 2wd_rover and 4wd_rover replace the Rover Zero and Rover Pro since they have
 Note: You have to install gazebo specifically for ROS. Our install script does not install gazebo. To install gazebo:
 ```sudo apt install ros-{DISTRO}-ros-gz```
 
+## Getting the Sensor Packages
+IMU and 2D LIDAR are the very fundamental requirements for autonomous indoor nagivation. Here we will be using the BNO055 IMU and the RPLidar S2 2D LiDAR sensor to provide accurate and robust localization and mapping for autonomous indoor navigation. Follow the steps mentioned below to download the packages for BNO055 IMU and Slamtec RPLIDAR S2:
+```bash
+cd <ros2_ws>/src
+git clone https://github.com/flynneva/bno055.git
+git clone -b ros2 https://github.com/Slamtec/rplidar_ros.git
+cd ~/<ros2_ws>
+source /opt/ros/<rosdistro>/setup.bash
+colcon build --symlink-install
+source install/setup.bash
+```
+Note: This serves as a starting point for implementing indoor autonomous navigation using the specified sensors. Our goal is to provide a simple yet effective solution that can be extended and customized based on specific project requirements. 
+
+## Setting Up the Sensors
+### Configuring UDEV Rules
+**Note:** To follow the intructions mentioned below, you need to install the [rover_install_scripts_ros2](https://github.com/RoverRobotics/rover_install_scripts_ros2) or you can do it on your own from [scratch](https://linuxconfig.org/tutorial-on-how-to-write-basic-udev-rules-in-linux)
+
+Edit the ``55-roverrobotics.rules``, which can be found in the ``rover_install_scripts_ros2`` within ``udev`` folder.
+You can see that ``rplidar`` has been already set up under ``# Sensor Udev Rules``. Let's setup the ``bno055``.
+```bash
+KERNEL=="ttyUSB*", ATTRS{idVendor}=="<enter_the_vendor_id>", ATTRS{idProduct}=="<enter_the_product_id>", MODE:="0777", SYMLINK+="bno055"
+```
+Copy the line mentioned above under ``# Sensor Udev Rules`` and enter the vendor and product ID of your sensors using ``lsusb``. (Refer [lsusb](https://linuxhint.com/use_lsusb_command/)
+
+```bash
+cd ~/rover_install_scripts_ros2/udev
+sudo cp 55-roverrobotics.rules /etc/udev/rules.d/55-roverrobotics.rules
+sudo udevadm control --reload-rules
+sudo udevadm trigger
+```
+Now, you should be able to see the ``bno055`` and ``rplidar`` in the list of your usb devices, using ``ls /dev``
+
+**Note:** If you have two devices with the same vendor and product ID, you can use ``ATTR{serial}`` to differentiate between the two devices. Use ``lsusb -v`` for the same.
+
+### Enabling and Setting Up the Ports of the Sensors
+Enable the ``rplidar`` and ``bno055`` within the ``accessories.yaml`` file, which can be found in the ``roverrobotics_driver`` package within the ``config`` folder.
+
+You can do this by setting the ``active`` parameter under ``ros__parameters`` of both the sensors as ``true``.
+
+In the same file ``accessories.yaml`` you can update the ``serial_port`` for ``rplidar`` as ``serial_port: "/dev/rplidar"`` and similarly for ``bno055``, ``uart_port: "/dev/bno055"``.
+
+Do not forget to perform a build of your workspace:
+```bash
+cd ~/<ros2_ws>/
+colcon build
+```
+
 ## Robot Description Setup
 Our ROS2 packages now implement URDF setups for all Rover Robots! The ``roverrobotics_description`` package implements all of the URDF configs and launches. You can view a URDF using the following:
 ```bash

--- a/README.md
+++ b/README.md
@@ -188,8 +188,28 @@ We have provided launch files and configs for Navigation2 and Slam Toolbox. They
 They can be launched with the following launch commands:
 ```
 ros2 launch roverrobotics_driver slam_launch.py
-ros2 launch roverrobotics_driver navigation_launch.py
+ros2 launch roverrobotics_driver navigation_launch.py map_file_name:=<path_to_map_file>
 ```
+
+If you are using simulation, specify the use_sim_time parameter to be true:
+```
+ros2 launch roverrobotics_driver slam_launch.py use_sim_time:=true
+ros2 launch roverrobotics_driver navigation_launch.py use_sim_time:=true map_file_name:=<path_to_map_file>
+```
+
+Note the parameter map_file_name. When using nav2, it is required to specify the absolute path to your map without any extension. Please use the slam toolbox plugin in rviz2 to save and serialize map files. For instance, if I saved my map as my_map, I would have the following files:
+
+my_map.pgm
+my_map.yaml
+my_map.posegraph
+my_map.data
+
+To properly launch nav2, I would run:
+
+``ros2 launch roverrobotics_driver navigation_launch.py map_file_name:=/path/to/map/my_map``
+
+Note, I omit any extensions when specifying the map and just use the name of the map. This way slam toolbox localization loads the map using all files specified above.
+
 These tools require the following transformations:
 ```
 base_link -> odom   ## Provided by the robot_localization package

--- a/README.md
+++ b/README.md
@@ -118,12 +118,12 @@ Note: You have to install gazebo specifically for ROS. Our install script does n
 ```sudo apt install ros-{DISTRO}-ros-gz```
 
 ## Getting the Sensor Packages
-IMU and 2D LIDAR are the very fundamental requirements for autonomous indoor nagivation. Here we will be using the BNO055 IMU and the RPLidar S2 2D LiDAR sensor to provide accurate and robust localization and mapping for autonomous indoor navigation. Follow the steps mentioned below to download the packages for BNO055 IMU and Slamtec RPLIDAR S2:
+At rover we have several mainly used sensors that we use. The BNO055 IMU and RP Lidar S2 are our goto IMU and Lidar sensors. Our install script does not automatically install these packages as not everyone needs them. To install them, follow the steps mentioned below to download the packages for BNO055 IMU and Slamtec RPLIDAR S2:
 ```bash
-cd <ros2_ws>/src
+cd rover_workspace/src
 git clone https://github.com/flynneva/bno055.git
 git clone -b ros2 https://github.com/Slamtec/rplidar_ros.git
-cd ~/<ros2_ws>
+cd ~/rover_workspace
 source /opt/ros/<rosdistro>/setup.bash
 colcon build --symlink-install
 source install/setup.bash
@@ -139,7 +139,7 @@ You can see that ``rplidar`` has been already set up under ``# Sensor Udev Rules
 ```bash
 KERNEL=="ttyUSB*", ATTRS{idVendor}=="<enter_the_vendor_id>", ATTRS{idProduct}=="<enter_the_product_id>", MODE:="0777", SYMLINK+="bno055"
 ```
-Copy the line mentioned above under ``# Sensor Udev Rules`` and enter the vendor and product ID of your sensors using ``lsusb``. (Refer [lsusb](https://linuxhint.com/use_lsusb_command/)
+Copy the line mentioned above under ``# Sensor Udev Rules`` and enter the vendor and product ID of your sensors using ``lsusb``. (Refer [lsusb](https://linuxhint.com/use_lsusb_command/))
 
 ```bash
 cd ~/rover_install_scripts_ros2/udev
@@ -160,7 +160,7 @@ In the same file ``accessories.yaml`` you can update the ``serial_port`` for ``r
 
 Do not forget to perform a build of your workspace:
 ```bash
-cd ~/<ros2_ws>/
+cd ~/rover_workspace
 colcon build
 ```
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Clone our repository into your workspace and ``colcon build`` like any other pac
 
 cd <ros2_ws>/src
 
-git clone https://github.com/RoverRobotics/ros2_roverrobotics_development.git -b ${ROS_DISTRO}
+git clone https://github.com/RoverRobotics/roverrobotics_ros2.git -b ${ROS_DISTRO}
 
 cd ..
 

--- a/roverrobotics_description/package.xml
+++ b/roverrobotics_description/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>roverrobotics_description</name>
-  <version>1.0.1</version>
+  <version>1.0.2</version>
   <description>Rover URDF and Robot Descriptions</description>
   <maintainer email="jack@roverrobotics.com">Jack Rivera</maintainer>
   <license>Apache-2.0</license>

--- a/roverrobotics_description/urdf/accessories/imu.urdf
+++ b/roverrobotics_description/urdf/accessories/imu.urdf
@@ -13,7 +13,7 @@
             <always_on>1</always_on>
             <update_rate>50</update_rate>
             <visualize>true</visualize>
-            <topic>imu/data_raw</topic>
+            <topic>imu/data</topic>
             <enable_metrics>true</enable_metrics>
             <ignition_frame_id>imu_link</ignition_frame_id>
         </sensor>

--- a/roverrobotics_description/urdf/accessories/rplidar_s2.urdf
+++ b/roverrobotics_description/urdf/accessories/rplidar_s2.urdf
@@ -20,7 +20,7 @@
     <joint name="lidar_to_payload" type="fixed">
         <parent link="payload_link"/>
         <child link="lidar_link"/>
-        <origin xyz="0.174 0 0.10" rpy="0 0 0"/>
+        <origin xyz="0.174 0 0.10" rpy="0 0 3.1415"/>
     </joint>
 
     <gazebo reference="lidar_link">

--- a/roverrobotics_description/urdf/rover_2wd.urdf
+++ b/roverrobotics_description/urdf/rover_2wd.urdf
@@ -17,8 +17,8 @@
     <!-- You can always link them elsewhere if you wish by editing accessories/<sensor>.urdf -->
     <xacro:property name="payload_z_offset" value="0.096" />
     <xacro:include filename="$(find roverrobotics_description)/urdf/accessories/rover_dev_payload.urdf" />
-    <!-- <xacro:include filename="$(find roverrobotics_description)/urdf/accessories/rplidar_s2.urdf" />
-    <xacro:include filename="$(find roverrobotics_description)/urdf/accessories/imu.urdf" /> -->
+    <xacro:include filename="$(find roverrobotics_description)/urdf/accessories/rplidar_s2.urdf" />
+    <xacro:include filename="$(find roverrobotics_description)/urdf/accessories/imu.urdf" />
 
     <!-- Robot Definition -->
     <link name="base_link" />

--- a/roverrobotics_description/urdf/rover_4wd.urdf
+++ b/roverrobotics_description/urdf/rover_4wd.urdf
@@ -14,8 +14,8 @@
     <!-- You can always link them elsewhere if you wish by editing accessories/<sensor>.urdf -->
     <xacro:property name="payload_z_offset" value="0.096" />
     <xacro:include filename="$(find roverrobotics_description)/urdf/accessories/rover_dev_payload.urdf" />
-    <!-- <xacro:include filename="$(find roverrobotics_description)/urdf/accessories/rplidar_s2.urdf" />
-    <xacro:include filename="$(find roverrobotics_description)/urdf/accessories/imu.urdf" /> -->
+    <xacro:include filename="$(find roverrobotics_description)/urdf/accessories/rplidar_s2.urdf" />
+    <xacro:include filename="$(find roverrobotics_description)/urdf/accessories/imu.urdf" />
 
     <!-- Robot Definition -->
     <link name="base_link" />

--- a/roverrobotics_driver/CMakeLists.txt
+++ b/roverrobotics_driver/CMakeLists.txt
@@ -16,6 +16,7 @@ find_package(std_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(nav_msgs REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
+find_package(sensor_msgs REQUIRED)
 #find_package(diagnostic_updater REQUIRED)
 
 #include_directories(include/)
@@ -58,6 +59,7 @@ ament_target_dependencies(roverrobotics_driver
   #rover_msgs
   nav_msgs
   tf2_geometry_msgs
+  sensor_msgs
   #diagnostic_updater
   )
 

--- a/roverrobotics_driver/config/nav2_params.yaml
+++ b/roverrobotics_driver/config/nav2_params.yaml
@@ -248,12 +248,12 @@ local_costmap:
       height: 8
       resolution: 0.05
       footprint: "[[0.27305, 0.1778],[0.27305, -0.1778],[-0.27305, -0.1778],[-0.27305, 0.1778]]"
-      footprint_padding: 0.025
+      footprint_padding: 0.01
       plugins: ["voxel_layer", "inflation_layer"]
       inflation_layer:
         plugin: "nav2_costmap_2d::InflationLayer"
-        cost_scaling_factor: 1.7
-        inflation_radius: 0.5
+        cost_scaling_factor: 3.0
+        inflation_radius: 0.35
       voxel_layer:
         plugin: "nav2_costmap_2d::VoxelLayer"
         enabled: True
@@ -311,8 +311,8 @@ global_costmap:
         map_subscribe_transient_local: True
       inflation_layer:
         plugin: "nav2_costmap_2d::InflationLayer"
-        cost_scaling_factor: 1.7
-        inflation_radius: 0.5
+        cost_scaling_factor: 3.0
+        inflation_radius: 0.4
       always_send_full_costmap: True
 
 map_server:

--- a/roverrobotics_driver/config/pro_config.yaml
+++ b/roverrobotics_driver/config/pro_config.yaml
@@ -5,7 +5,7 @@ roverrobotics_driver:
     motor_control_p_gain: 0.4
     motor_control_i_gain: 0.000
     motor_control_d_gain: 0.7
-    publish_tf: true
+    publish_tf: false
     # robot_status_topic: "/"
     # robot_status_frequency: 60.0
     # robot_info_request_topic:

--- a/roverrobotics_driver/include/roverrobotics_ros2_driver.hpp
+++ b/roverrobotics_driver/include/roverrobotics_ros2_driver.hpp
@@ -7,6 +7,7 @@
 #include <cmath>
 #include <geometry_msgs/msg/transform_stamped.hpp>
 
+
 #include "protocol_pro.hpp"
 #include "protocol_zero_2.hpp"
 #include "differential_robot.hpp"
@@ -16,14 +17,16 @@
 #include "geometry_msgs/msg/twist.hpp"
 #include "nav_msgs/msg/odometry.hpp"
 #include "rclcpp/node_options.hpp"
-#include "rclcpp/rclcpp.hpp"
+#include <rclcpp/rclcpp.hpp>
 #include "rclcpp/time.hpp"
 #include "rcppmath/rolling_mean_accumulator.hpp"
 #include "std_msgs/msg/bool.hpp"
 #include "std_msgs/msg/float32.hpp"
+#include "sensor_msgs/msg/battery_state.hpp"
 #include "std_msgs/msg/float32_multi_array.hpp"
 #include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
 #include "tf2_ros/transform_broadcaster.h"
+
 // #include <librover/status_data.hpp>
 using namespace std::chrono_literals;
 
@@ -94,6 +97,8 @@ class RobotDriver : public rclcpp::Node {
       robot_status_publisher_;  // publish robot state
   rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr
       odometry_publisher_;  // Odom Publisher
+   rclcpp::Publisher<sensor_msgs::msg::BatteryState>::SharedPtr
+      battery_soc_publisher_;  // Battery Status Publisher
   std::unique_ptr<tf2_ros::TransformBroadcaster> odom_tf_pub; // Odom TF Broadcaster
 
   // Timepoint / Timer

--- a/roverrobotics_driver/include/roverrobotics_ros2_driver.hpp
+++ b/roverrobotics_driver/include/roverrobotics_ros2_driver.hpp
@@ -52,13 +52,15 @@ class RobotDriver : public rclcpp::Node {
   const std::string ESTOP_RESET_TOPIC_DEFAULT_ = "/soft_estop/reset";
   const std::string TRIM_TOPIC_DEFAULT_ = "/trim_event";
   const bool ESTOP_STATE_DEFAULT_ = false;
-  const std::string CONTROL_MODE_DEFAULT_ = "OPEN_LOOP";
+  const std::string CONTROL_MODE_DEFAULT_ = "INDEPENDENT_WHEEL";
   const float LINEAR_TOP_SPEED_DEFAULT_ = 2;
   const float ANGULAR_TOP_SPEED_DEFAULT_ = 2;
   const bool PUB_ODOM_TF_DEFAULT_ = false;
   const float PID_P_DEFAULT_ = 0;
   const float PID_I_DEFAULT_ = 0;
   const float PID_D_DEFAULT_ = 0;
+  const float LIN_COVAR_DEFAULT = 0.05;
+  const float YAW_COVAR_DEFAULT = 0.4;
   const float ROBOT_ODOM_FREQUENCY_DEFAULT_ = 30;
   Control::angular_scaling_params angular_scaling_params_ = {0, 0, 0, 0, 0};
   const float ANGULAR_SCALING_A_DEFAULT_ = 0;
@@ -127,6 +129,8 @@ class RobotDriver : public rclcpp::Node {
   bool estop_state_;
   std::string control_mode_name_;
   Control::robot_motion_mode_t control_mode_;
+  float linear_covariance;
+  float yaw_covariance;
   double linear_top_speed_;
   double angular_top_speed_;
 

--- a/roverrobotics_driver/launch/navigation_launch.py
+++ b/roverrobotics_driver/launch/navigation_launch.py
@@ -33,9 +33,6 @@ def generate_launch_description():
     bringup_dir = get_package_share_directory('nav2_bringup')
     launch_dir = os.path.join(bringup_dir, 'launch')
 
-    rl_launch_path = os.path.join(rover_dir, 'launch', 'robot_localizer.launch.py')
-    robot_localizer_launch = IncludeLaunchDescription(PythonLaunchDescriptionSource(rl_launch_path))
-
     # Create the launch configuration variables
     namespace = LaunchConfiguration('namespace')
     use_namespace = LaunchConfiguration('use_namespace')
@@ -119,7 +116,9 @@ def generate_launch_description():
         'log_level', default_value='info',
         description='log level')
     
-   
+    rl_launch_path = os.path.join(get_package_share_directory("roverrobotics_driver"), 'launch', 'robot_localizer.launch.py')
+    robot_localizer_launch = IncludeLaunchDescription(PythonLaunchDescriptionSource(rl_launch_path),
+        launch_arguments={'use_sim_time': use_sim_time}.items())
 
     # Specify the actions
     bringup_cmd_group = GroupAction([

--- a/roverrobotics_driver/launch/robot_localizer.launch.py
+++ b/roverrobotics_driver/launch/robot_localizer.launch.py
@@ -29,7 +29,7 @@ def generate_launch_description():
     	executable='ekf_node',
     	name='ekf_filter_node',
     	output='screen',
-    	parameters=[{'use_sim_time': use_sim_time}, robot_localization_file_path]
+    	parameters=[robot_localization_file_path, {'use_sim_time': use_sim_time}]
     	)
     
     ld = LaunchDescription()

--- a/roverrobotics_driver/launch/slam_launch.py
+++ b/roverrobotics_driver/launch/slam_launch.py
@@ -14,9 +14,6 @@ from launch_ros.actions import Node
 
 def generate_launch_description():
     
-    rl_launch_path = os.path.join(get_package_share_directory("roverrobotics_driver"), 'launch', 'robot_localizer.launch.py')
-    robot_localizer_launch = IncludeLaunchDescription(PythonLaunchDescriptionSource(rl_launch_path))
-    
     # Slam toolbox launch setup
     use_sim_time = LaunchConfiguration('use_sim_time')
     slam_params_file = LaunchConfiguration('slam_params_file')
@@ -30,6 +27,11 @@ def generate_launch_description():
         default_value=os.path.join(get_package_share_directory("roverrobotics_driver"),
                                    'config/slam_configs', 'mapper_params_online_async.yaml'),
         description='Full path to the ROS2 parameters file to use for the slam_toolbox node')
+
+
+    rl_launch_path = os.path.join(get_package_share_directory("roverrobotics_driver"), 'launch', 'robot_localizer.launch.py')
+    robot_localizer_launch = IncludeLaunchDescription(PythonLaunchDescriptionSource(rl_launch_path),
+        launch_arguments={'use_sim_time': use_sim_time}.items())
 
     start_async_slam_toolbox_node = Node(
         parameters=[

--- a/roverrobotics_driver/launch/slam_launch.py
+++ b/roverrobotics_driver/launch/slam_launch.py
@@ -43,11 +43,13 @@ def generate_launch_description():
 
     ld = LaunchDescription()
 
+    # Add sim time arg
+    ld.add_action(declare_use_sim_time_argument)
+    
     # Add localization to launch description
     ld.add_action(robot_localizer_launch)
 
     # Add slam setup to launch description
-    ld.add_action(declare_use_sim_time_argument)
     ld.add_action(declare_slam_params_file_cmd)
     ld.add_action(start_async_slam_toolbox_node)
     

--- a/roverrobotics_driver/library/librover/include/status_data.hpp
+++ b/roverrobotics_driver/library/librover/include/status_data.hpp
@@ -31,8 +31,8 @@ struct robotData {
   signed short int battery2_temp;
   unsigned short int battery1_current;
   unsigned short int battery2_current;
-  bool battery1_SOC;
-  bool battery2_SOC;
+  unsigned short int battery1_SOC;
+  unsigned short int battery2_SOC;
   unsigned short int battery1_fault_flag;
   unsigned short int battery2_fault_flag;
 

--- a/roverrobotics_driver/library/librover/src/differential_robot.cpp
+++ b/roverrobotics_driver/library/librover/src/differential_robot.cpp
@@ -298,7 +298,13 @@ void DifferentialRobot::unpack_comm_response(std::vector<uint8_t> robotmsg) {
       robotstatus_.battery2_temp = 0;
       robotstatus_.battery1_current = vesc_all_input_current_;
       robotstatus_.battery2_current = 0;
-      robotstatus_.battery1_SOC = 0;
+      if(robotstatus_.battery1_voltage >= 42.0) {
+        robotstatus_.battery1_SOC = 100;
+      } else if (robotstatus_.battery1_voltage <= 34.0){
+        robotstatus_.battery1_SOC = 0.0;
+      } else {
+        robotstatus_.battery1_SOC = 12.5 * robotstatus_.battery1_voltage - 425;
+      }
       robotstatus_.battery2_SOC = 0;
       robotstatus_.battery1_fault_flag = 0;
       robotstatus_.battery2_fault_flag = 0;

--- a/roverrobotics_driver/library/librover/src/protocol_pro.cpp
+++ b/roverrobotics_driver/library/librover/src/protocol_pro.cpp
@@ -20,7 +20,7 @@ ProProtocolObject::ProProtocolObject(const char *device,
       REG_MOTOR_FB_CURRENT_LEFT, REG_MOTOR_FB_CURRENT_RIGHT,
       REG_MOTOR_TEMP_LEFT,       REG_MOTOR_TEMP_RIGHT,
       REG_MOTOR_CHARGER_STATE,   BuildNO,
-      BATTERY_VOLTAGE_A};
+      BATTERY_VOLTAGE_A,         REG_PWR_BAT_VOLTAGE_A};
   pid_ = pid;
   PidGains oldgain = {pid_.kp, pid_.ki, pid_.kd};
   if (robot_mode_ != Control::OPEN_LOOP)
@@ -221,6 +221,9 @@ void ProProtocolObject::unpack_comm_response(std::vector<uint8_t> robotmsg) {
           robotstatus_.motor2_temp = b;
           break;
         case REG_PWR_BAT_VOLTAGE_A:
+          if (robotstatus_.robot_firmware == 10009) {
+            robotstatus_.battery1_SOC = b;
+          }
           break;
         case REG_PWR_BAT_VOLTAGE_B:
           break;
@@ -231,7 +234,9 @@ void ProProtocolObject::unpack_comm_response(std::vector<uint8_t> robotmsg) {
         case EncoderInterval_2:
           break;
         case REG_ROBOT_REL_SOC_A:
-          robotstatus_.battery1_SOC = b;
+          if (robotstatus_.robot_firmware != OVF_FIXED_FIRM_VER_) {
+            robotstatus_.battery1_SOC = b;
+          }
           break;
         case REG_ROBOT_REL_SOC_B:
           break;
@@ -257,28 +262,44 @@ void ProProtocolObject::unpack_comm_response(std::vector<uint8_t> robotmsg) {
         case BATTERY_STATUS_B:
           break;
         case BATTERY_MODE_A:
-          robotstatus_.battery1_fault_flag = b;
+          if (robotstatus_.robot_firmware != OVF_FIXED_FIRM_VER_) {
+            robotstatus_.battery1_fault_flag = b;
+          }
           break;
         case BATTERY_MODE_B:
-          robotstatus_.battery2_fault_flag = b;
+          if (robotstatus_.robot_firmware != OVF_FIXED_FIRM_VER_) {
+            robotstatus_.battery2_fault_flag = b;
+          }
           break;
         case BATTERY_TEMP_A:
-          robotstatus_.battery1_temp = b;
+          if (robotstatus_.robot_firmware != OVF_FIXED_FIRM_VER_) {
+            robotstatus_.battery1_temp = b;
+          }
           break;
         case BATTERY_TEMP_B:
-          robotstatus_.battery2_temp = b;
+          if (robotstatus_.robot_firmware != OVF_FIXED_FIRM_VER_) {
+            robotstatus_.battery2_temp = b;
+          }
           break;
         case BATTERY_VOLTAGE_A:
-          robotstatus_.battery1_voltage = b;
+          if (robotstatus_.robot_firmware != OVF_FIXED_FIRM_VER_) {
+            robotstatus_.battery1_voltage = b;
+          }
           break;
         case BATTERY_VOLTAGE_B:
-          robotstatus_.battery2_voltage = b;
+          if (robotstatus_.robot_firmware != OVF_FIXED_FIRM_VER_) {
+            robotstatus_.battery2_voltage = b;
+          }
           break;
         case BATTERY_CURRENT_A:
-          robotstatus_.battery1_current = b;
+          if (robotstatus_.robot_firmware != OVF_FIXED_FIRM_VER_) {
+            robotstatus_.battery1_current = b;
+          }
           break;
         case BATTERY_CURRENT_B:
-          robotstatus_.battery2_current = b;
+          if (robotstatus_.robot_firmware != OVF_FIXED_FIRM_VER_) {
+            robotstatus_.battery2_current = b;
+          }
           break;
       }
       // !Same battery system for both A and B on this robot

--- a/roverrobotics_driver/library/librover/src/protocol_zero_2.cpp
+++ b/roverrobotics_driver/library/librover/src/protocol_zero_2.cpp
@@ -353,6 +353,13 @@ void Zero2ProtocolObject::unpack_comm_response(std::vector<uint8_t> robotmsg) {
     robotstatus_.battery1_current = vesc_all_input_current_;
     robotstatus_.battery2_current = 0;
     robotstatus_.battery1_SOC = 0;
+    if(robotstatus_.battery1_voltage >= 16.5) {
+      robotstatus_.battery1_SOC = 100;
+    } else if (robotstatus_.battery1_voltage <= 13.5){
+      robotstatus_.battery1_SOC = 0.0;
+    } else {
+      robotstatus_.battery1_SOC = 33.3333 * robotstatus_.battery1_voltage - 450;
+    }
     robotstatus_.battery2_SOC = 0;
     robotstatus_.battery1_fault_flag = 0;
     robotstatus_.battery2_fault_flag = 0;

--- a/roverrobotics_driver/package.xml
+++ b/roverrobotics_driver/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>roverrobotics_driver</name>
-  <version>1.0.1</version>
+  <version>1.0.2</version>
   <description>
     ROS2 Wrapper for Rover Robots
   </description>

--- a/roverrobotics_driver/package.xml
+++ b/roverrobotics_driver/package.xml
@@ -21,6 +21,7 @@
   <depend>tf2_geometry_msgs</depend>
   <depend>diagnostic_updater</depend>
   <depend>nav_msgs</depend>
+  <depend>sensor_msgs</depend>
 
 
   <export>

--- a/roverrobotics_driver/src/roverrobotics_ros2_driver.cpp
+++ b/roverrobotics_driver/src/roverrobotics_ros2_driver.cpp
@@ -105,6 +105,8 @@ RobotDriver::RobotDriver() : Node("roverrobotics", rclcpp::NodeOptions().use_int
       robot_info_topic_, rclcpp::QoS(32));
   robot_status_publisher_ = create_publisher<std_msgs::msg::Float32MultiArray>(
       robot_status_topic_, rclcpp::QoS(31));
+  battery_soc_publisher_ = create_publisher<sensor_msgs::msg::BatteryState>(
+      "rover_" + robot_type_ + "/battery_status", rclcpp::QoS(10));
   if (pub_odom_tf_) {
      RCLCPP_INFO(get_logger(),
                 "Publishing Robot TF on %s at %.2Fhz", odom_topic_.c_str(),
@@ -272,6 +274,13 @@ void RobotDriver::publish_robot_status() {
   robot_status.data.push_back(robot_data_.motor3_sensor1);
   robot_status.data.push_back(robot_data_.motor3_sensor2);
   robot_status_publisher_->publish(robot_status);
+
+
+  // Battery Status Topic
+  auto battery_msg = sensor_msgs::msg::BatteryState();
+  battery_msg.voltage = robot_data_.battery1_voltage;
+  battery_msg.percentage = robot_data_.battery1_SOC;
+  battery_soc_publisher_->publish(battery_msg);
 }
 
 void RobotDriver::update_odom() {

--- a/roverrobotics_driver/src/roverrobotics_ros2_driver.cpp
+++ b/roverrobotics_driver/src/roverrobotics_ros2_driver.cpp
@@ -278,8 +278,15 @@ void RobotDriver::publish_robot_status() {
 
   // Battery Status Topic
   auto battery_msg = sensor_msgs::msg::BatteryState();
-  battery_msg.voltage = robot_data_.battery1_voltage;
-  battery_msg.percentage = robot_data_.battery1_SOC;
+  if (robot_type_ != "pro"){
+    battery_msg.percentage = robot_data_.battery1_SOC;
+    battery_msg.voltage = robot_data_.battery1_voltage;
+    battery_msg.current = robot_data_.battery1_current;
+  } else {
+    battery_msg.percentage = robot_data_.battery1_SOC / 10.0;
+    battery_msg.voltage = robot_data_.battery2_voltage;
+    battery_msg.current = robot_data_.battery2_current;
+  }
   battery_soc_publisher_->publish(battery_msg);
 }
 

--- a/roverrobotics_gazebo/launch/2wd_rover_gazebo.launch.py
+++ b/roverrobotics_gazebo/launch/2wd_rover_gazebo.launch.py
@@ -65,7 +65,7 @@ def generate_launch_description():
             "/tf@tf2_msgs/msg/TFMessage[ignition.msgs.Pose_V",
             '/joint_states@sensor_msgs/msg/JointState[gz.msgs.Model',
             '/scan@sensor_msgs/msg/LaserScan@gz.msgs.LaserScan',
-            '/imu/data_raw@sensor_msgs/msg/Imu@gz.msgs.IMU',
+            '/imu/data@sensor_msgs/msg/Imu@gz.msgs.IMU',
         ],
     )
 

--- a/roverrobotics_gazebo/launch/4wd_rover_gazebo.launch.py
+++ b/roverrobotics_gazebo/launch/4wd_rover_gazebo.launch.py
@@ -65,7 +65,7 @@ def generate_launch_description():
             "/tf@tf2_msgs/msg/TFMessage[ignition.msgs.Pose_V",
             '/joint_states@sensor_msgs/msg/JointState[gz.msgs.Model',
             '/scan@sensor_msgs/msg/LaserScan@gz.msgs.LaserScan',
-            '/imu/data_raw@sensor_msgs/msg/Imu@gz.msgs.IMU',
+            '/imu/data@sensor_msgs/msg/Imu@gz.msgs.IMU',
         ],
     )
 

--- a/roverrobotics_gazebo/launch/flipper_gazebo.launch.py
+++ b/roverrobotics_gazebo/launch/flipper_gazebo.launch.py
@@ -65,7 +65,7 @@ def generate_launch_description():
             "/tf@tf2_msgs/msg/TFMessage[ignition.msgs.Pose_V",
             '/joint_states@sensor_msgs/msg/JointState[gz.msgs.Model',
             '/scan@sensor_msgs/msg/LaserScan@gz.msgs.LaserScan',
-            '/imu/data_raw@sensor_msgs/msg/Imu@gz.msgs.IMU',
+            '/imu/data@sensor_msgs/msg/Imu@gz.msgs.IMU',
         ],
     )
 

--- a/roverrobotics_gazebo/launch/indoor_miti_gazebo.launch.py
+++ b/roverrobotics_gazebo/launch/indoor_miti_gazebo.launch.py
@@ -65,7 +65,7 @@ def generate_launch_description():
             "/tf@tf2_msgs/msg/TFMessage[ignition.msgs.Pose_V",
             '/joint_states@sensor_msgs/msg/JointState[gz.msgs.Model',
             '/scan@sensor_msgs/msg/LaserScan@gz.msgs.LaserScan',
-            '/imu/data_raw@sensor_msgs/msg/Imu@gz.msgs.IMU',
+            '/imu/data@sensor_msgs/msg/Imu@gz.msgs.IMU',
         ],
     )
 

--- a/roverrobotics_gazebo/launch/mini_gazebo.launch.py
+++ b/roverrobotics_gazebo/launch/mini_gazebo.launch.py
@@ -65,7 +65,7 @@ def generate_launch_description():
             "/tf@tf2_msgs/msg/TFMessage[ignition.msgs.Pose_V",
             '/joint_states@sensor_msgs/msg/JointState[gz.msgs.Model',
             '/scan@sensor_msgs/msg/LaserScan@gz.msgs.LaserScan',
-            '/imu/data_raw@sensor_msgs/msg/Imu@gz.msgs.IMU',
+            '/imu/data@sensor_msgs/msg/Imu@gz.msgs.IMU',
         ],
     )
 

--- a/roverrobotics_gazebo/launch/miti_gazebo.launch.py
+++ b/roverrobotics_gazebo/launch/miti_gazebo.launch.py
@@ -65,7 +65,7 @@ def generate_launch_description():
             "/tf@tf2_msgs/msg/TFMessage[ignition.msgs.Pose_V",
             '/joint_states@sensor_msgs/msg/JointState[gz.msgs.Model',
             '/scan@sensor_msgs/msg/LaserScan@gz.msgs.LaserScan',
-            '/imu/data_raw@sensor_msgs/msg/Imu@gz.msgs.IMU',
+            '/imu/data@sensor_msgs/msg/Imu@gz.msgs.IMU',
         ],
     )
 

--- a/roverrobotics_gazebo/package.xml
+++ b/roverrobotics_gazebo/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>roverrobotics_gazebo</name>
-  <version>1.0.1</version>
+  <version>1.0.2</version>
   <description>Rover Ignition Gazebo Simulation Package</description>
   <maintainer email="jack@roverrobotics.com">Jack Rivera</maintainer>
   <license>Apache-2.0</license>

--- a/roverrobotics_input_manager/package.xml
+++ b/roverrobotics_input_manager/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
     <name>roverrobotics_input_manager</name>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
     <description>Contains Rover provided teleoperation applications.</description>
     <maintainer email="jack@roverrobotics.com">Jack Rivera</maintainer>
     <license>Apache-2.0</license>


### PR DESCRIPTION
- Fixes gazebo sim time bug
- Adjusts nav2 params
- Adjusts URDF for rover pro and zero
- Adjusts pro config to default tf publisher to false
- Fixes rplidar orientation
- Adds preliminary battery monitoring for pro, zero, and mini/miti with UART connections (Can not supported)